### PR TITLE
Incongruent direction indentation

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1079,20 +1079,24 @@ impl ShapeLine {
                             }
                             word_range_width += word_width;
                             continue;
-                        } else if wrap == Wrap::Glyph
+                        }
+
+                        let on_first_line = visual_lines.is_empty();
+                        let word_fits_on_current_line =
+                            current_visual_line.w + word_width <= line_width;
+
+                        if wrap == Wrap::Glyph
                             // Make sure that the word is able to fit on its own line, if not, fall back to Glyph wrapping.
                             || (wrap == Wrap::WordOrGlyph && word_width > line_width)
-                            // If we're on the first line
-                            || (wrap == Wrap::WordOrGlyph && visual_lines.len() == 0 &&
-                            // and we can't fit this word on the first line on its own
-                            current_visual_line.w + word_width > line_width)
+                            // If we're on the first line and can't fit the word on its own
+                            || (wrap == Wrap::WordOrGlyph && on_first_line && !word_fits_on_current_line)
                         {
                             // Commit the current line so that the word starts on the next line.
                             if word_range_width > 0.
                                 && ((wrap == Wrap::WordOrGlyph && word_width > line_width)
                                     || (wrap == Wrap::WordOrGlyph
-                                        && visual_lines.len() == 0
-                                        && current_visual_line.w + word_width > line_width))
+                                        && on_first_line
+                                        && !word_fits_on_current_line))
                             {
                                 add_to_visual_line(
                                     &mut current_visual_line,
@@ -1213,20 +1217,22 @@ impl ShapeLine {
                             continue;
                         }
 
+                        let on_first_line = visual_lines.is_empty();
+                        let word_fits_on_current_line =
+                            current_visual_line.w + word_width <= line_width;
+
                         if wrap == Wrap::Glyph
                             // Make sure that the word is able to fit on it's own line, if not, fall back to Glyph wrapping.
                             || (wrap == Wrap::WordOrGlyph && word_width > line_width)
-                            // If we're on the first line
-                            || (wrap == Wrap::WordOrGlyph && visual_lines.len() == 0 &&
-                            // and we can't fit the rest of this word on the current line
-                            current_visual_line.w + word_width > line_width)
+                            // If we're on the first line and can't fit the word on its own
+                            || (wrap == Wrap::WordOrGlyph && on_first_line && !word_fits_on_current_line)
                         {
                             // Commit the current line so that the word starts on the next line.
                             if word_range_width > 0.
                                 && ((wrap == Wrap::WordOrGlyph && word_width > line_width)
                                     || (wrap == Wrap::WordOrGlyph
-                                        && visual_lines.len() == 0
-                                        && current_visual_line.w + word_width > line_width))
+                                        && on_first_line
+                                        && !word_fits_on_current_line))
                             {
                                 add_to_visual_line(
                                     &mut current_visual_line,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1080,13 +1080,19 @@ impl ShapeLine {
                             word_range_width += word_width;
                             continue;
                         } else if wrap == Wrap::Glyph
-                            // Make sure that the word is able to fit on it's own line, if not, fall back to Glyph wrapping.
+                            // Make sure that the word is able to fit on its own line, if not, fall back to Glyph wrapping.
                             || (wrap == Wrap::WordOrGlyph && word_width > line_width)
+                            // If we're on the first line
+                            || (wrap == Wrap::WordOrGlyph && visual_lines.len() == 0 &&
+                            // and we can't fit this word on the first line on its own
+                            current_visual_line.w + word_width > line_width)
                         {
                             // Commit the current line so that the word starts on the next line.
                             if word_range_width > 0.
-                                && wrap == Wrap::WordOrGlyph
-                                && word_width > line_width
+                                && ((wrap == Wrap::WordOrGlyph && word_width > line_width)
+                                    || (wrap == Wrap::WordOrGlyph
+                                        && visual_lines.len() == 0
+                                        && current_visual_line.w + word_width > line_width))
                             {
                                 add_to_visual_line(
                                     &mut current_visual_line,
@@ -1212,13 +1218,15 @@ impl ShapeLine {
                             || (wrap == Wrap::WordOrGlyph && word_width > line_width)
                             // If we're on the first line
                             || (wrap == Wrap::WordOrGlyph && visual_lines.len() == 0 &&
-                            // and we can't fit the rest of this word on the line
-                            (current_visual_line.w + word_width > line_width))
+                            // and we can't fit the rest of this word on the current line
+                            current_visual_line.w + word_width > line_width)
                         {
                             // Commit the current line so that the word starts on the next line.
                             if word_range_width > 0.
-                                && wrap == Wrap::WordOrGlyph
-                                && word_width > line_width
+                                && ((wrap == Wrap::WordOrGlyph && word_width > line_width)
+                                    || (wrap == Wrap::WordOrGlyph
+                                        && visual_lines.len() == 0
+                                        && current_visual_line.w + word_width > line_width))
                             {
                                 add_to_visual_line(
                                     &mut current_visual_line,

--- a/tests/wrap_stability.rs
+++ b/tests/wrap_stability.rs
@@ -111,39 +111,6 @@ fn wrap_extra_line() {
     assert_eq!(overflow_lines, 4);
 }
 
-#[test]
-fn wrap_bidirectional() {
-    let mut font_system = FontSystem::new();
-    let font_size = 14.0;
-    let line_height = 20.0;
-    let buffer_width = 80.0;
-
-    let metrics = Metrics::new(font_size, line_height);
-
-    let mut plain_buffer = Buffer::new(&mut font_system, metrics);
-
-    let mut buffer = plain_buffer.borrow_with(&mut font_system);
-
-    // Add some text
-    buffer.set_wrap(Wrap::WordOrGlyph);
-    buffer.set_text(
-        "breakfast, إفطار, lunch (غداء) and dinner - عشاء",
-        Attrs::new().family(cosmic_text::Family::Name("Inter")),
-        Shaping::Advanced,
-    );
-
-    // Set a size for the text buffer, in pixels
-    buffer.set_size(buffer_width, 1000.0);
-
-    let layout_line = buffer.line_layout(0).unwrap().first().unwrap();
-    assert!(
-        layout_line.w <= buffer_width,
-        "layout line width ({}) was greater than buffer width ({})",
-        layout_line.w,
-        buffer_width
-    );
-}
-
 #[allow(dead_code)]
 fn dbg_layout_lines(text: &str, lines: &[LayoutLine]) {
     for line in lines {

--- a/tests/wrap_stability.rs
+++ b/tests/wrap_stability.rs
@@ -111,6 +111,39 @@ fn wrap_extra_line() {
     assert_eq!(overflow_lines, 4);
 }
 
+#[test]
+fn wrap_bidirectional() {
+    let mut font_system = FontSystem::new();
+    let font_size = 14.0;
+    let line_height = 20.0;
+    let buffer_width = 80.0;
+
+    let metrics = Metrics::new(font_size, line_height);
+
+    let mut plain_buffer = Buffer::new(&mut font_system, metrics);
+
+    let mut buffer = plain_buffer.borrow_with(&mut font_system);
+
+    // Add some text
+    buffer.set_wrap(Wrap::WordOrGlyph);
+    buffer.set_text(
+        "breakfast, إفطار, lunch (غداء) and dinner - عشاء",
+        Attrs::new().family(cosmic_text::Family::Name("Inter")),
+        Shaping::Advanced,
+    );
+
+    // Set a size for the text buffer, in pixels
+    buffer.set_size(buffer_width, 1000.0);
+
+    let layout_line = buffer.line_layout(0).unwrap().first().unwrap();
+    assert!(
+        layout_line.w <= buffer_width,
+        "layout line width ({}) was greater than buffer width ({})",
+        layout_line.w,
+        buffer_width
+    );
+}
+
 #[allow(dead_code)]
 fn dbg_layout_lines(text: &str, lines: &[LayoutLine]) {
     for line in lines {


### PR DESCRIPTION
(Also added a missing check in the congruent-directions case.)

Note that bidirectional text currently doesn't wrap correctly -- see pop-os/cosmic-text#252 for details. This PR only ensures that the first line accounts for indentation.