### PR TITLE
Bump dependencies so we can standardize on single  (and newer) versions at the app level.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ rust-version = "1.65"
 [dependencies]
 bitflags = "2.4.1"
 cosmic_undo_2 = { version = "0.2.0", optional = true }
-fontdb = { version = "0.16", default-features = false }
+fontdb = { version = "0.22", default-features = false }
 hashbrown = { version = "0.14.1", optional = true, default-features = false }
 libm = { version = "0.2.8", optional = true }
 log = "0.4.20"
 modit = { version = "0.1.4", optional = true }
 rangemap = "1.4.0"
 rustc-hash = { version = "1.1.0", default-features = false }
-rustybuzz = { version = "0.14", default-features = false, features = ["libm"] }
+rustybuzz = { version = "0.18", default-features = false }
 self_cell = "1.0.1"
 swash = { version = "0.1.17", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
-ttf-parser = { version = "0.21", default-features = false }
+ttf-parser = { version = "0.24.1", default-features = false, features = ["opentype-layout"] }
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.1"
@@ -38,7 +38,7 @@ features = ["hardcoded-data"]
 [features]
 default = ["std", "swash", "fontconfig"]
 fontconfig = ["fontdb/fontconfig", "std"]
-no_std = ["rustybuzz/libm", "hashbrown", "dep:libm"]
+no_std = ["hashbrown", "dep:libm"]
 shape-run-cache = []
 std = [
     "fontdb/memmap",


### PR DESCRIPTION
I tested locally, via a `path = ""` version definition in `warpui`'s Cargo.toml, that we can use this set of versions (plus some version bumps in our own crates) to use much newer versions and eliminate duplicate versions of `ttf-parser`, `owned_ttf_parser`, `rustybuzz`, and `fontdb`.