### PR TITLE
Bump version for a handful of dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ rust-version = "1.65"
 [dependencies]
 bitflags = "2.4.1"
 cosmic_undo_2 = { version = "0.2.0", optional = true }
-fontdb = { version = "0.22", default-features = false }
+fontdb = { version = "0.23", default-features = false }
 hashbrown = { version = "0.14.1", optional = true, default-features = false }
 libm = { version = "0.2.8", optional = true }
 log = "0.4.20"
 modit = { version = "0.1.4", optional = true }
 rangemap = "1.4.0"
 rustc-hash = { version = "1.1.0", default-features = false }
-rustybuzz = { version = "0.18", default-features = false }
+rustybuzz = { version = "0.20.1", default-features = false }
 self_cell = "1.0.1"
 swash = { version = "0.1.17", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
-ttf-parser = { version = "0.24.1", default-features = false, features = ["opentype-layout"] }
+ttf-parser = { version = "0.25.1", default-features = false, features = ["opentype-layout"] }
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.1"


### PR DESCRIPTION
Goal here is to use the latest version of `rustybuzz`.  Bumping `ttf-parser` and `fontdb` allows us to avoid introducing duplicate dependencies in the `warp` crate when we combine this with some version bumps to `warp` and `warpui` crate dependencies.

I tested that there are no compilation issues with a local build of Warp that used this commit.