### PR TITLE
Fix incorrect computation of ascent and descent.

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1563,8 +1563,8 @@ impl ShapeLine {
             };
             layout_lines.push(LayoutLine {
                 w: current_line_width,
-                max_ascent: max_ascent * font_size,
-                max_descent: max_descent * font_size,
+                max_ascent,
+                max_descent,
                 line_height_opt,
                 glyphs,
             });


### PR DESCRIPTION
[This commit](https://github.com/warpdotdev/cosmic-text/commit/167d0d8157af6f5901af0fa272f65733c3c9c96a) modified the computation here; it's not clear why.

Upstream doesn't perform any multiplication here, and I don't see any reason to do this.  Reverting this change fixes incorrect behavior when using these values to compute text baseline position.